### PR TITLE
Check for zero-width characters in annotation2BIO.py

### DIFF
--- a/annotation2BIO.py
+++ b/annotation2BIO.py
@@ -129,7 +129,8 @@ def generate_BIO(sents, entities, file_id="", no_overlap=False, record_pos=False
     for i, sent in enumerate(sents):
         nsent = []
         for j, token in enumerate(sent):
-            if (token[1][0] == token[1][1]) and (token[2][0] == token[2][1]): # Check for ZWSP characters
+            if token[1][0] == token[1][1]: # Check for ZWSP characters
+                logger.warning(f"Ignoring zero-width character encountered in position {j*(i+1)} in file {file_id}")
                 continue
             if record_pos:
                 token.append((i, j))

--- a/annotation2BIO.py
+++ b/annotation2BIO.py
@@ -129,6 +129,8 @@ def generate_BIO(sents, entities, file_id="", no_overlap=False, record_pos=False
     for i, sent in enumerate(sents):
         nsent = []
         for j, token in enumerate(sent):
+            if (token[1][0] == token[1][1]) and (token[2][0] == token[2][1]): # Check for ZWSP characters
+                continue
             if record_pos:
                 token.append((i, j))
             if not entity:


### PR DESCRIPTION
Avoids adding ZW-characters to BIO files that would prevent the file from being processed due to mismatch in length between tokens and predicted labels.